### PR TITLE
Add organization policies feature

### DIFF
--- a/datastores/organization_policies.ts
+++ b/datastores/organization_policies.ts
@@ -1,0 +1,14 @@
+import { DefineDatastore, Schema } from "deno-slack-sdk/mod.ts";
+
+const datastore = DefineDatastore(
+  {
+    name: "organization_policies",
+    primary_key: "key",
+    attributes: {
+      key: { type: Schema.types.string },
+      value: { type: Schema.types.string },
+    },
+  } as const,
+);
+
+export default datastore;

--- a/functions/internals/components.ts
+++ b/functions/internals/components.ts
@@ -10,6 +10,8 @@ import {
   C,
   CMapper,
   fetchUserDetails,
+  OP,
+  OPMapper,
   P,
   PH,
   PHMapper,
@@ -42,6 +44,7 @@ export interface Components {
   ph: DataMapper<PH>;
   us: DataMapper<US>;
   p: DataMapper<P>;
+  op: DataMapper<OP>;
   au: DataMapper<AU>;
   user: string;
   settings: SavedAttributes<US>;
@@ -115,6 +118,7 @@ export async function injectComponents(
     c: CMapper(client, logLevel),
     ph,
     p: PMapper(client, logLevel),
+    op: OPMapper(client, logLevel),
     au,
     holidays,
     yyyymmdd: _yyyymmdd,

--- a/functions/internals/constants.ts
+++ b/functions/internals/constants.ts
@@ -10,6 +10,7 @@ export class CallbackId {
   static ProjectMainView = "project_main_view";
   static AddProject = "add_project";
   static EditProjct = "edit_project";
+  static OrganizationPolicies = "organization_policies";
 }
 
 export class BlockId {
@@ -43,6 +44,7 @@ export class ActionId {
   static Refresh = "refresh";
   static AddProject = "add_project";
   static EditProject = "edit_project";
+  static OrganizationPolicyChange = "organization_policy_change";
 }
 
 export class MenuItem {
@@ -51,6 +53,7 @@ export class MenuItem {
   static Calendar = "calendar";
   static MonthlyReport = "monthly_report";
   static ProjectSettings = "project_settings";
+  static OrganizationPolicies = "organization_policies";
 }
 
 export class Emoji {
@@ -90,6 +93,7 @@ export class Label {
   static AddProject = "Add Project";
   static EditProject = "Edit Project";
   static ProjectSettings = "Project Settings";
+  static OrganizationPolicies = "Organization Policies";
   static StartWork = "Start work";
   static FinishWork = "Finish work";
   static StartBreakTime = "Start break time";
@@ -126,6 +130,9 @@ export class Label {
   static ProjectCodeTextValidationError =
     "A project code can consist of alphanumeric characters, dashes (-), and underscores(_).";
   static CodeAlreadyExists = "The code already exists";
+  static ManualEntryPermitted = "Manual Entry Permitted";
+  static OrganizationPolicyValue_Permitted = "Permitted";
+  static OrganizationPolicyValue_Restricted = "Restricted";
 }
 
 export class EntryType {

--- a/functions/internals/datastore.ts
+++ b/functions/internals/datastore.ts
@@ -13,6 +13,7 @@ import Countries from "../../datastores/countries.ts";
 import PublicHolidays from "../../datastores/public_holidays.ts";
 import AdminUsers from "../../datastores/admin_users.ts";
 import Projects from "../../datastores/projects.ts";
+import OrganizationPolicies from "../../datastores/organization_policies.ts";
 
 import { todayYYYYMMDD } from "./datetime.ts";
 
@@ -24,8 +25,9 @@ export type C = typeof Countries.definition;
 export type PH = typeof PublicHolidays.definition;
 export type AU = typeof AdminUsers.definition;
 export type P = typeof Projects.definition;
+export type OP = typeof OrganizationPolicies.definition;
 
-function createDataMapper<DEF extends TE | US | C | PH | AU | P>(
+function createDataMapper<DEF extends TE | US | C | PH | AU | P | OP>(
   def: DEF,
   client: Client,
   logLevel: LogLevel,
@@ -54,6 +56,9 @@ export function AUMapper(client: Client, logLevel: LogLevel): DataMapper<AU> {
 }
 export function PMapper(client: Client, logLevel: LogLevel): DataMapper<P> {
   return createDataMapper(Projects.definition, client, logLevel);
+}
+export function OPMapper(client: Client, logLevel: LogLevel): DataMapper<OP> {
+  return createDataMapper(OrganizationPolicies.definition, client, logLevel);
 }
 
 export async function fetchUserDetails(

--- a/functions/internals/i18n.ts
+++ b/functions/internals/i18n.ts
@@ -22,6 +22,7 @@ labels[Label.MoveToToday] = { "ja": "今日の画面へ移動" };
 labels[Label.UserSettings] = { "ja": "ユーザー設定" };
 labels[Label.Calendar] = { "ja": "カレンダー" };
 labels[Label.MonthlyReport] = { "ja": "月次レポート" };
+labels[Label.OrganizationPolicies] = { "ja": "組織ポリシー" };
 labels[Label.ProjectMain] = { "ja": "プロジェクト" };
 labels[Label.ProjectSummary] = { "ja": "プロジェクトのサマリー" };
 labels[Label.AddProject] = { "ja": "プロジェクト追加" };
@@ -68,6 +69,9 @@ labels[Label.CodeAlreadyExists] = { "ja": "このコードはすでに存在し�
 labels[Label.ProjectCodeTextValidationError] = {
   "ja": "コードには英数字か '-', '_' のみを使用できます",
 };
+labels[Label.ManualEntryPermitted] = { "ja": "履歴の手入力・編集を許可する" };
+labels[Label.OrganizationPolicyValue_Permitted] = { "ja": "可" };
+labels[Label.OrganizationPolicyValue_Restricted] = { "ja": "不可" };
 
 export function i18n(english: string, language: string): string {
   const entry = labels[english];

--- a/functions/internals/organization_policies.ts
+++ b/functions/internals/organization_policies.ts
@@ -1,0 +1,52 @@
+import { DataMapper } from "deno-slack-data-mapper/mod.ts";
+import { OP } from "./datastore.ts";
+import { Label } from "./constants.ts";
+
+export interface OrganizationPolicyDetails {
+  label: string;
+  values: OrganizationPolicyValueDetails[];
+}
+export interface OrganizationPolicyValueDetails {
+  value: string;
+  label: string;
+}
+export const OrganizationPolices: Record<string, OrganizationPolicyDetails> =
+  {};
+
+export class OrganizationPolicyKey {
+  static IsManualEntryPermitted = "is_manual_entry_permitted";
+}
+
+export class OrganizationPolicyValue {
+  static Permitted = "permitted";
+  static Restricted = "restricted";
+}
+
+// slack datastore put '{"datastore":"organization_policies","item": {"key":"is_manual_entry_permitted","value":"restricted"}}'
+OrganizationPolices[OrganizationPolicyKey.IsManualEntryPermitted] = {
+  label: Label.ManualEntryPermitted,
+  values: [
+    {
+      value: OrganizationPolicyValue.Permitted,
+      label: Label.OrganizationPolicyValue_Permitted,
+    },
+    {
+      value: OrganizationPolicyValue.Restricted,
+      label: Label.OrganizationPolicyValue_Restricted,
+    },
+  ],
+};
+
+interface isManualEntryPermittedArgs {
+  op: DataMapper<OP>;
+}
+export async function isManualEntryPermitted(
+  { op }: isManualEntryPermittedArgs,
+): Promise<boolean> {
+  const row = await op.findById(OrganizationPolicyKey.IsManualEntryPermitted);
+  const value: string | undefined = row.item.value;
+  if (value) {
+    return value !== OrganizationPolicyValue.Restricted;
+  }
+  return true;
+}

--- a/manifest.ts
+++ b/manifest.ts
@@ -7,6 +7,7 @@ import Countries from "./datastores/countries.ts";
 import PublicHolidays from "./datastores/public_holidays.ts";
 import AdminUsers from "./datastores/admin_users.ts";
 import Projects from "./datastores/projects.ts";
+import OrganizationPolicies from "./datastores/organization_policies.ts";
 
 export default Manifest({
   name: "Timesheet",
@@ -25,6 +26,7 @@ export default Manifest({
     PublicHolidays,
     Projects,
     AdminUsers,
+    OrganizationPolicies,
   ],
   botScopes: [
     "commands",


### PR DESCRIPTION
This pull request adds a new feature to manage organization-wide policies. As an initial step, this PR allows turning on/off the flag to enable manual entries of time logs. In order to adhere to Japanese labor law, restricting manually created time records is recommended as the best practice. With such a strict policy, employees are required to use a time card or an equivalent. When "Add entry" and "Edit entry" features within this app are restricted, this app can function as a virtual time card for users. Adding "organization_policies" table will be useful for future enhancements of this app.